### PR TITLE
Cleanup jupyterhub dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ via code. This can then be deployed on any Grafana instance!
 
 4. An API key with 'owner' permissions. This is per-organization, and you can make a new one
    by going to the configuration pane for your Grafana (the gear icon on the left bar), and
-   selecting 'API Keys'.
+   selecting 'API Keys'. The owner permission is needed to query list of data sources so we
+   can auto-populate template variable options (such as list of hubs).
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ via code. This can then be deployed on any Grafana instance!
 
 3. A recent version of Grafana, with a prometheus data source already added.
 
-4. An API key with 'editor' permissions. This is per-organization, and you can make a new one
+4. An API key with 'owner' permissions. This is per-organization, and you can make a new one
    by going to the configuration pane for your Grafana (the gear icon on the left bar), and
    selecting 'API Keys'.
 
 ## Deployment
 
-There's a helper `deploy.bash` script that can deploy the dashboard to any grafana installation.
+There's a helper `deploy.py` script that can deploy the dashboard to any grafana installation.
 
 ```bash
 export GRAFANA_TOKEN="<API-TOKEN-FOR-YOUR-GRAFANA>

--- a/README.md
+++ b/README.md
@@ -47,17 +47,6 @@ export GRAFANA_TOKEN="<API-TOKEN-FOR-YOUR-GRAFANA>
 This creates a folder called 'JupyterHub Default Dashboards' in your grafana, and adds
 a couple of dashboards to it.
 
-On clusters with multiple hubs, it is important to show per-hub dashboards. Unfortunately,
-Grafana doesn't populate the 'hub' variable properly by default. You'll need to:
-
-1. Go to the dashboard that needs per-hub usage
-2. Go to settings (gear icon in top right)
-3. Select the 'hub' variable
-4. Click the 'Update' button
-
-This will show you the hubs on your cluster, and then you can select them from the dropdown.
-Unfortunately, right now there seem to be no easy way to [automatically update these](https://community.grafana.com/t/template-update-variable-api/1882/4).
-
 **NOTE: ANY CHANGES YOU MAKE VIA THE GRAFANA UI WILL BE OVERWRITTEN NEXT TIME YOU RUN deploy.bash.
 TO MAKE CHANGES, EDIT THE JSONNET FILE AND DEPLOY AGAIN**
 

--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -11,14 +11,6 @@ local heatmapPanel = grafana.heatmapPanel;
 local jupyterhub = import './jupyterhub.libsonnet';
 local standardDims = jupyterhub.standardDims;
 
-local templates = [
-  template.datasource(
-    'PROMETHEUS_DS',
-    'prometheus',
-    'Prometheus',
-    hide='label',
-  ),
-];
 
 // Cluster-wide stats
 local userNodes = graphPanel.new(
@@ -402,8 +394,6 @@ dashboard.new(
   'Cluster Information',
   tags=['jupyterhub', 'kubernetes'],
   editable=true
-).addTemplates(
-  templates
 ).addPanel(
   row.new('Cluster Stats'), {},
 ).addPanel(

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -14,20 +14,10 @@ local jupyterhub = import 'jupyterhub.libsonnet';
 local standardDims = jupyterhub.standardDims;
 
 local templates = [
-  template.datasource(
-    'PROMETHEUS_DS',
-    'prometheus',
-    'Prometheus',
-    hide='label',
-  ),
   template.new(
     'hub',
-    datasource='$PROMETHEUS_DS',
-    query='label_values(kube_namespace_status_phase, namespace)',
-    regex='.*-(?:staging|prod)$',
-    // FIXME: Grafana needs a manual 'refresh variables' before it populates this.
-    // Maybe another API call?
-    current='jupyterhub'
+    datasource='prometheus',
+    query='label_values(kube_service_labels{service="hub"}, namespace)',
   ),
 ];
 

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -22,50 +22,6 @@ local templates = [
 ];
 
 
-// Cluster-wide stats
-local userNodes = graphPanel.new(
-  'User Nodes',
-  decimalsY1=0,
-  legend_show=false,
-  min=0,
-).addTarget(
-  prometheus.target(
-    expr='sum(kube_node_info{node=~".*user.*"})',
-  )
-);
-
-local clusterUtilization = graphPanel.new(
-  'Cluster Utilization',
-  formatY1='percentunit',
-  min=0,
-  stack=true,
-).addTargets([
-  prometheus.target(
-    |||
-      sum(
-        kube_pod_container_resource_requests_memory_bytes{node=~".*user.*"}
-        %s
-        and on (pod) (kube_pod_container_status_ready)
-      ) / sum(
-        kube_node_status_allocatable_memory_bytes{node=~".*user.*"}
-      )
-    ||| % jupyterhub.onComponentLabel('singleuser-server'),
-    legendFormat='User Pods'
-  ),
-  prometheus.target(
-    |||
-      sum(
-        kube_pod_container_resource_requests_memory_bytes{node=~".*user.*"}
-        %s
-        and on (pod) (kube_pod_container_status_ready)
-      ) / sum(
-        kube_node_status_allocatable_memory_bytes{node=~".*user.*"}
-      )
-    ||| % jupyterhub.onComponentLabel('.*placeholder', cmp='=~'),
-    legendFormat='Placeholder Pods'
-  ),
-]);
-
 // Hub usage stats
 local currentRunningUsers = graphPanel.new(
   'Current running users',
@@ -95,6 +51,26 @@ local userMemoryDistribution = heatmapPanel.new(
     |||
       sum(
         container_memory_working_set_bytes
+        %s
+      ) by (pod)
+    ||| % jupyterhub.onComponentLabel('singleuser-server', group_left='container'),
+    interval='600s',
+    intervalFactor=1,
+  ),
+]);
+
+local userCPUDistribution = heatmapPanel.new(
+  'User CPU usage distribution',
+  // xBucketSize and interval must match to get correct values out of heatmaps
+  xBucketSize='600s',
+  yAxis_format='percentunit',
+  yAxis_min=0,
+  color_colorScheme='interpolateViridis',
+).addTargets([
+  prometheus.target(
+    |||
+      sum(
+        irate(container_cpu_usage_seconds_total[5m])
         %s
       ) by (pod)
     ||| % jupyterhub.onComponentLabel('singleuser-server', group_left='container'),
@@ -143,11 +119,6 @@ local hubResponseLatency = graphPanel.new(
 ]);
 
 
-local proxyMemory = jupyterhub.memoryPanel('Proxy', component='proxy');
-local proxyCPU = jupyterhub.cpuPanel('Proxy', component='proxy');
-local hubMemory = jupyterhub.memoryPanel('Hub', component='hub');
-local hubCPU = jupyterhub.cpuPanel('Hub', component='hub');
-
 // with multi=true, component='singleuser-server' means all components *except* singleuser-server
 local allComponentsMemory = jupyterhub.memoryPanel('All JupyterHub Components', component='singleuser-server', multi=true);
 local allComponentsCPU = jupyterhub.cpuPanel('All JupyterHub Components', component='singleuser-server', multi=true);
@@ -190,40 +161,23 @@ local usersPerNode = graphPanel.new(
 ]);
 
 
-// Cluster diagnostics
-local userNodesRSS = graphPanel.new(
-  'User Nodes Memory usage (RSS)',
-  formatY1='bytes',
-  min=0,
-).addTargets([
-  prometheus.target(
-    'sum(node_memory_Active_bytes{kubernetes_node=~".*user.*"}) by (kubernetes_node)',
-    legendFormat='{{kubernetes_node}}'
-  ),
-]);
-
-//
-local userNodesCPU = graphPanel.new(
-  'User Nodes CPU',
-  formatY1='short',
-  decimalsY1=0,
-  min=0,
-).addTargets([
-  prometheus.target(
-    'sum(rate(node_cpu_seconds_total{mode!="idle", kubernetes_node=~".*user.*"}[5m])) by (kubernetes_node)',
-    legendFormat='{{kubernetes_node}}'
-  ),
-]);
-
-
 local nonRunningPods = graphPanel.new(
-  'Non Running User Pods',
+  'Non Running Pods',
+  description=|||
+    Pods in a non-running state in the hub's namespace.
+
+    Pods stuck in non-running states often indicate an error condition
+  |||,
   decimalsY1=0,
   min=0,
   stack=true,
 ).addTargets([
   prometheus.target(
-    'sum(kube_pod_status_phase{phase!="Running"}) by (phase)',
+    |||
+      sum(
+        kube_pod_status_phase{phase!="Running", namespace="$hub"}
+      ) by (phase)
+    |||,
     legendFormat='{{phase}}'
   ),
 ]);
@@ -236,51 +190,28 @@ dashboard.new(
   editable=true
 ).addTemplates(
   templates
-
-).addPanel(
-  row.new('Cluster Stats'), {}
-).addPanel(
-  userNodes, {}
-).addPanel(
-  clusterUtilization, {}
-
 ).addPanel(
   row.new('Hub usage stats for $hub'), {}
 ).addPanel(
   currentRunningUsers, {}
 ).addPanel(
-  usersPerNode, {}
-).addPanel(
   userAgeDistribution, {}
 ).addPanel(
+  userCPUDistribution, {},
+).addPanel(
   userMemoryDistribution, {}
-
 ).addPanel(
   row.new('Hub Diagnostics for $hub'), {}
 ).addPanel(
   serverStartTimes, {}
 ).addPanel(
   hubResponseLatency, {}
-
-).addPanel(
-  hubCPU, {}
-).addPanel(
-  hubMemory, {}
-).addPanel(
-  proxyCPU, {}
-).addPanel(
-  proxyMemory, {}
 ).addPanel(
   allComponentsCPU, { h: standardDims.h * 1.5 },
 ).addPanel(
   allComponentsMemory, { h: standardDims.h * 1.5 },
-
-).addPanel(
-  row.new('Cluster Diagnostics'), {}
-).addPanel(
-  userNodesRSS, {}
-).addPanel(
-  userNodesCPU, {}
 ).addPanel(
   nonRunningPods, {}
+).addPanel(
+  usersPerNode, {}
 )

--- a/dashboards/usage-stats.jsonnet
+++ b/dashboards/usage-stats.jsonnet
@@ -12,16 +12,6 @@ local heatmapPanel = grafana.heatmapPanel;
 
 local standardDims = { w: 12, h: 12 };
 
-local templates = [
-  template.datasource(
-    'PROMETHEUS_DS',
-    'prometheus',
-    'Prometheus',
-    hide='label',
-  ),
-];
-
-
 local monthlyActiveUsers = graphPanel.new(
   'Active users (over 30 days)',
   bars=true,
@@ -123,9 +113,6 @@ dashboard.new(
   tags=['jupyterhub'],
   editable=true,
   time_from='now-30d'
-).addTemplates(
-  templates
-
 ).addPanel(
   monthlyActiveUsers, {},
 ).addPanel(

--- a/deploy.py
+++ b/deploy.py
@@ -6,8 +6,10 @@ from glob import glob
 from functools import partial
 import subprocess
 from urllib.request import urlopen, Request
+from urllib.parse import urlencode
 from urllib.error import HTTPError
 from copy import deepcopy
+import re
 
 # UID for the folder under which our dashboards will be setup
 DEFAULT_FOLDER_UID = '70E5EE84-1217-4021-A89E-1E3DE0566D93'
@@ -79,13 +81,64 @@ def layout_dashboard(dashboard):
     return dashboard
 
 def deploy_dashboard(dashboard_path, folder_uid, api):
+    db = build_dashboard(dashboard_path)
+    db = layout_dashboard(db)
+    db = populate_template_variables(api, db)
+
     data = {
-        'dashboard': layout_dashboard(build_dashboard(dashboard_path)),
+        'dashboard': db,
         'folderId': folder_uid,
         'overwrite': True
     }
     api('/dashboards/db', data)
 
+
+def get_label_values(api, ds_id, template_query):
+    """
+    Return response to a `label_values` template query
+
+    `label_values` isn't actually a prometheus thing - it is an API call that
+    grafana makes. This function tries to mimic that. Useful for populating variables
+    in a dashboard
+    """
+    match = re.match(r'label_values\((?P<query>.*),\s*(?P<label>.*)\)', template_query)
+    query = match.group('query')
+    label = match.group('label')
+    query = {'match[]': query}
+    # Send a request to the backing prometheus datastore
+    proxy_url = f'/datasources/proxy/{ds_id}/api/v1/series?{urlencode(query)}'
+
+    metrics = api(proxy_url)['data']
+    return sorted(set(m[label] for m in metrics))
+
+
+def populate_template_variables(api, db):
+    """
+    Populate options for template variables.
+
+    For list of hubs and similar, users should be able to select a hub from
+    a dropdown list. This is not auto populated by grafana if you are
+    using the API (https://community.grafana.com/t/template-update-variable-api/1882/4)
+    so we do it here.
+    """
+    # We gonna make modifications to db, so let's make a copy
+    db = deepcopy(db)
+
+    for var in db.get('templating', {}).get('list', []):
+        if var['type'] != 'query':
+            # We don't support populating datasource templates
+            continue
+        template_query = var['query']
+
+        sources = api('/datasources')
+
+        # Use the first default default prometheus datasource
+        prom_id = [s['id'] for s in sources if s['type'] == 'prometheus' and s['isDefault']][0]
+
+        var['options'] = [
+            {"text": l, "value": l} for l in get_label_values(api, prom_id, template_query)
+        ]
+    return db
 
 def main():
     parser = argparse.ArgumentParser()

--- a/deploy.py
+++ b/deploy.py
@@ -130,10 +130,7 @@ def populate_template_variables(api, db):
             continue
         template_query = var['query']
 
-        sources = api('/datasources')
-
-        # Use the first default default prometheus datasource
-        prom_id = [s['id'] for s in sources if s['type'] == 'prometheus' and s['isDefault']][0]
+        prom_id = api(f'/datasources/id/{var["datasource"]}')['id']
 
         var['options'] = [
             {"text": l, "value": l} for l in get_label_values(api, prom_id, template_query)

--- a/deploy.py
+++ b/deploy.py
@@ -130,6 +130,7 @@ def populate_template_variables(api, db):
             continue
         template_query = var['query']
 
+        # This requires our token to have owner permissions
         prom_id = api(f'/datasources/id/{var["datasource"]}')['id']
 
         var['options'] = [


### PR DESCRIPTION
- Remove cluster-wide graphs, since they have been moved to
  the cluster dashboard
- Add CPU usage distribution graph for user servers
- Remove per-component CPU / Memory usage graphs, since we have
  a consolidated graph for them.
- Show all non-running pods in the current namespace, not just
  non-running user pods, since they indicate error conditions.

Depends on #12 