### PR TITLE
Support selecting multiple hubs in jupyterhub dashboard

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -18,6 +18,9 @@ local templates = [
     'hub',
     datasource='prometheus',
     query='label_values(kube_service_labels{service="hub"}, namespace)',
+    // Allow viewing dashboard for multiple combined hubs
+    includeAll=true,
+    multi=true
   ),
 ];
 
@@ -109,11 +112,11 @@ local hubResponseLatency = graphPanel.new(
   min=0,
 ).addTargets([
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace="$hub"}[5m])) by (le))',
+    'histogram_quantile(0.99, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
     legendFormat='99th percentile'
   ),
   prometheus.target(
-    'histogram_quantile(0.50, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace="$hub"}[5m])) by (le))',
+    'histogram_quantile(0.50, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
     legendFormat='50th percentile'
   ),
 ]);
@@ -133,11 +136,11 @@ local serverStartTimes = graphPanel.new(
 ).addTargets([
   prometheus.target(
     // Metrics from hub seems to have `kubernetes_namespace` rather than just `namespace`
-    'histogram_quantile(0.99, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace="$hub"}[5m])) by (le))',
+    'histogram_quantile(0.99, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
     legendFormat='99th percentile'
   ),
   prometheus.target(
-    'histogram_quantile(0.5, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace="$hub"}[5m])) by (le))',
+    'histogram_quantile(0.5, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
     legendFormat='50th percentile'
   ),
 ]);
@@ -175,7 +178,7 @@ local nonRunningPods = graphPanel.new(
   prometheus.target(
     |||
       sum(
-        kube_pod_status_phase{phase!="Running", namespace="$hub"}
+        kube_pod_status_phase{phase!="Running", namespace=~"$hub"}
       ) by (phase)
     |||,
     legendFormat='{{phase}}'

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -194,7 +194,7 @@ dashboard.new(
 ).addTemplates(
   templates
 ).addPanel(
-  row.new('Hub usage stats for $hub'), {}
+  row.new('Hub usage stats'), {}
 ).addPanel(
   currentRunningUsers, {}
 ).addPanel(
@@ -204,7 +204,7 @@ dashboard.new(
 ).addPanel(
   userMemoryDistribution, {}
 ).addPanel(
-  row.new('Hub Diagnostics for $hub'), {}
+  row.new('Hub Diagnostics'), {}
 ).addPanel(
   serverStartTimes, {}
 ).addPanel(

--- a/dashboards/jupyterhub.libsonnet
+++ b/dashboards/jupyterhub.libsonnet
@@ -25,7 +25,7 @@ local prometheus = grafana.prometheus;
         cmp,
         component,
         if namespace != null then
-          ', namespace="%s"' % namespace
+          ', namespace=~"%s"' % namespace
         else
           '',
       ]


### PR DESCRIPTION
Grafana produces a regex for $hub when multiple hubs are selected,
so we need to use `=~` for all namespaces selectors, rather than =