### PR TITLE
select sole hub by default

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -133,9 +133,18 @@ def populate_template_variables(api, db):
         # This requires our token to have admin permissions
         prom_id = api(f'/datasources/id/{var["datasource"]}')['id']
 
-        var['options'] = [
-            {"text": l, "value": l} for l in get_label_values(api, prom_id, template_query)
-        ]
+        labels = get_label_values(api, prom_id, template_query)
+        var["options"] = [{"text": l, "value": l} for l in labels]
+        if labels and not var.get("current"):
+            # default selection: all current values
+            # logical alternative: pick just the first
+            var["current"] = {
+                "selected": True,
+                "tags": [],
+                "text": ', '.join(labels),
+                "value": labels,
+            }
+
     return db
 
 def main():

--- a/deploy.py
+++ b/deploy.py
@@ -135,15 +135,16 @@ def populate_template_variables(api, db):
 
         labels = get_label_values(api, prom_id, template_query)
         var["options"] = [{"text": l, "value": l} for l in labels]
-        if labels and not var.get("current"):
+        if len(labels) == 1 and not var.get("current"):
             # default selection: all current values
             # logical alternative: pick just the first
             var["current"] = {
                 "selected": True,
                 "tags": [],
-                "text": ', '.join(labels),
-                "value": labels,
+                "text": labels[:1],
+                "value": labels[:1],
             }
+            var["options"][0]["selected"] = True
 
     return db
 


### PR DESCRIPTION
Currently, the jupyterhub dashboard is empty by default and you have to pick which hub you want, which has been a bit frustrating for me with just one Hub, which I imagine is most deployments.

Logical alternatives, all of which behave the same for a single-hub deployment, but have different behaviors for multi-hub deployments:

- select all (first draft, not anymore)
- always pick just one, presumably the first alphabetically
- leave empty if there are multiples, set selection if there's just one (no change for multi-hub, fixes my problem for single-hub) (this pr)
