### PR TITLE
exclude empty-name container metrics in resource usage

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -54,7 +54,10 @@ local userMemoryDistribution = heatmapPanel.new(
   prometheus.target(
     |||
       sum(
-        container_memory_working_set_bytes
+        # exclude name="" because the same container can be reported
+        # with both no name and `name=k8s_...`,
+        # in which case sum() by (pod) reports double the actual metric
+        container_memory_working_set_bytes{name!=""}
         %s
       ) by (pod)
     ||| % jupyterhub.onComponentLabel('singleuser-server', group_left='container'),
@@ -74,7 +77,10 @@ local userCPUDistribution = heatmapPanel.new(
   prometheus.target(
     |||
       sum(
-        irate(container_cpu_usage_seconds_total[5m])
+        # exclude name="" because the same container can be reported
+        # with both no name and `name=k8s_...`,
+        # in which case sum() by (pod) reports double the actual metric
+        irate(container_cpu_usage_seconds_total{name!=""}[5m])
         %s
       ) by (pod)
     ||| % jupyterhub.onComponentLabel('singleuser-server', group_left='container'),

--- a/dashboards/jupyterhub.libsonnet
+++ b/dashboards/jupyterhub.libsonnet
@@ -118,7 +118,12 @@ local prometheus = grafana.prometheus;
   memoryPanel(name, component, multi=false):: self.componentResourcePanel(
     std.format('%s Memory (Working Set)', [name]),
     component=component,
-    metric='container_memory_working_set_bytes{name!=""}',
+    metric=|||
+      # exclude name="" because the same container can be reported
+      # with both no name and `name=k8s_...`,
+      # in which case sum() reports double the actual metric
+      container_memory_working_set_bytes{name!=""}'
+    |||,
     formatY1='bytes',
     multi=multi,
   ),
@@ -136,7 +141,12 @@ local prometheus = grafana.prometheus;
   cpuPanel(name, component, multi=false):: self.componentResourcePanel(
     std.format('%s CPU', [name]),
     component=component,
-    metric='irate(container_cpu_usage_seconds_total{name!=""}[5m])',
+    metric=|||
+      # exclude name="" because the same container can be reported
+      # with both no name and `name=k8s_...`,
+      # in which case sum() reports double the actual metric
+      irate(container_cpu_usage_seconds_total{name!=""}[5m])
+    |||,
     // decimals=1 with percentunit means round to nearest 10%
     decimalsY1=1,
     formatY1='percentunit',


### PR DESCRIPTION
Including these often results in double-counting metrics for the same container

It's unclear why, but it seems that one container can be reported both with a `name=k8s...` and no name. When this happens, `sum() by (pod)` will report twice the actual resource usage.

I already added this exclusion when I discovered it in componentResourcePanel, but this PR adds comments explaining why and applies the same exclusion to the heatmaps.

