### PR TITLE
compatibility with prometheus chart v15

### DIFF
--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -163,7 +163,7 @@ local clusterCPUCommitment = graphPanel.new(
       ) by (label_cloud_google_com_gke_nodepool)
       /
       sum(
-        # Total allocatable memory on a node
+        # Total allocatable CPU on a node
         kube_node_status_allocatable{resource="cpu"}
         # Add nodepool name as label
         * on(node) group_left(label_cloud_google_com_gke_nodepool)
@@ -195,7 +195,7 @@ local nodeCPUCommit = graphPanel.new(
   prometheus.target(
     |||
       sum(
-        # Get individual container memory limits
+        # Get individual container CPU limits
         kube_pod_container_resource_requests{resource="cpu"}
         # Ignore containers from pods that aren't currently running or scheduled
         # FIXME: This isn't the best metric here, evaluate what is.
@@ -205,7 +205,7 @@ local nodeCPUCommit = graphPanel.new(
       ) by (node)
       /
       sum(
-        # Get individual container memory requests
+        # Get individual container CPU requests
         kube_node_status_allocatable{resource="cpu"}
       ) by (node)
     |||,

--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -225,12 +225,12 @@ local nodeMemoryUtil = graphPanel.new(
           node_memory_MemFree_bytes + # Unused bytes
           node_memory_Cached_bytes + # Shared memory + temporary disk cache
           node_memory_Buffers_bytes # Very temporary buffer memory cache for disk i/o
-        ) by (kubernetes_node)
+        ) by (node)
         /
-        sum(node_memory_MemTotal_bytes) by (kubernetes_node)
+        sum(node_memory_MemTotal_bytes) by (node)
       )
     |||,
-    legendFormat='{{kubernetes_node}}'
+    legendFormat='{{node}}'
   ),
 ]);
 
@@ -247,15 +247,15 @@ local nodeCPUUtil = graphPanel.new(
 ).addTargets([
   prometheus.target(
     |||
-      sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (kubernetes_node)
+      sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (node)
       /
       sum(
-        # Rename 'node' label to 'kubernetes_node', since kube-state-metrics to match metric from
+        # Rename 'node' label to 'node', since kube-state-metrics to match metric from
         # kube-state-metrics to prometheus node exporter
-        label_replace(kube_node_status_capacity_cpu_cores, "kubernetes_node", "$1", "node", "(.*)")
-      ) by (kubernetes_node)
+        label_replace(kube_node_status_capacity_cpu_cores, "node", "$1", "node", "(.*)")
+      ) by (node)
     |||,
-    legendFormat='{{kubernetes_node}}'
+    legendFormat='{{node}}'
   ),
 ]);
 

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -130,11 +130,11 @@ local hubResponseLatency = graphPanel.new(
   datasource='$PROMETHEUS_DS'
 ).addTargets([
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
+    'histogram_quantile(0.99, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
     legendFormat='99th percentile'
   ),
   prometheus.target(
-    'histogram_quantile(0.50, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
+    'histogram_quantile(0.50, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
     legendFormat='50th percentile'
   ),
 ]);
@@ -154,12 +154,12 @@ local serverStartTimes = graphPanel.new(
   datasource='$PROMETHEUS_DS'
 ).addTargets([
   prometheus.target(
-    // Metrics from hub seems to have `kubernetes_namespace` rather than just `namespace`
-    'histogram_quantile(0.99, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
+    // Metrics from hub seems to have `namespace` rather than just `namespace`
+    'histogram_quantile(0.99, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
     legendFormat='99th percentile'
   ),
   prometheus.target(
-    'histogram_quantile(0.5, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", kubernetes_namespace=~"$hub"}[5m])) by (le))',
+    'histogram_quantile(0.5, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
     legendFormat='50th percentile'
   ),
 ]);
@@ -174,7 +174,7 @@ local usersPerNode = graphPanel.new(
     |||
       sum(
           # kube_pod_info.node identifies the pod node,
-          # while kube_pod_labels.kubernetes_node is the metrics exporter's node
+          # while kube_pod_labels.node is the metrics exporter's node
           kube_pod_info{node!=""}
           %s
       ) by (node)

--- a/dashboards/support.jsonnet
+++ b/dashboards/support.jsonnet
@@ -23,8 +23,8 @@ local userNodesNFSOps = graphPanel.new(
   datasource='$PROMETHEUS_DS'
 ).addTargets([
   prometheus.target(
-    'sum(rate(node_nfs_requests_total[5m])) by (kubernetes_node) > 0',
-    legendFormat='{{kubernetes_node}}'
+    'sum(rate(node_nfs_requests_total[5m])) by (node) > 0',
+    legendFormat='{{ node }}'
   ),
 ]);
 
@@ -35,8 +35,8 @@ local userNodesIOWait = graphPanel.new(
   datasource='$PROMETHEUS_DS'
 ).addTargets([
   prometheus.target(
-    'sum(rate(node_nfs_requests_total[5m])) by (kubernetes_node)',
-    legendFormat='{{kubernetes_node}}'
+    'sum(rate(node_nfs_requests_total[5m])) by (node)',
+    legendFormat='{{ node }}'
   ),
 ]);
 


### PR DESCRIPTION
in prometheus chart v15 / kube-state-metrics 2.0:

- kubernetes_ prefix removed from `node` and `namespace`
- resource metrics like `kube_node_status_allocatable_memory_bytes` are no longer separate series, but rather a single series selected by `resource` (`kube_node_status_allocatable{resource="memory"}`)

not sure how to keep this tool compatible across prometheus chart changes, but this PR has been [deployed on mybinder.org](https://grafana.mybinder.org/d/hub-dashboard/jupyterhub-dashboard?orgId=1&var-PROMETHEUS_DS=prometheus&var-hub=All)