### PR TITLE
Remove unnecessary term in query

### DIFF
--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -70,7 +70,7 @@ local userPods = graphPanel.new(
           kube_pod_status_phase{phase="Running"}
         ) by (pod)
         * on (pod) group_right() group(
-          kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~".*"}
+          kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server"}
         ) by (namespace, pod)
       ) by (namespace)
     |||,


### PR DESCRIPTION
It's a regex that matches everything, and so just slows the query down.

See https://github.com/berkeley-dsep-infra/datahub/issues/3984#issuecomment-1343125440