### PR TITLE
Exclude SpawnProgressAPIHandler from latency metrics

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -202,11 +202,39 @@ local hubResponseLatency = graphPanel.new(
   datasource='$PROMETHEUS_DS'
 ).addTargets([
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
+    |||
+      histogram_quantile(
+        0.99,
+        sum(
+          rate(
+            jupyterhub_request_duration_seconds_bucket{
+              app="jupyterhub",
+              namespace=~"$hub",
+              # Ignore SpawnProgressAPIHandler, as it is a EventSource stream
+              # and keeps long lived connections open
+              handler!="jupyterhub.apihandlers.users.SpawnProgressAPIHandler"
+            }[5m]
+          )
+        ) by (le))
+    |||,
     legendFormat='99th percentile'
   ),
   prometheus.target(
-    'histogram_quantile(0.50, sum(rate(jupyterhub_request_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
+    |||
+      histogram_quantile(
+        0.50,
+        sum(
+          rate(
+            jupyterhub_request_duration_seconds_bucket{
+              app="jupyterhub",
+              namespace=~"$hub",
+              # Ignore SpawnProgressAPIHandler, as it is a EventSource stream
+              # and keeps long lived connections open
+              handler!="jupyterhub.apihandlers.users.SpawnProgressAPIHandler"
+            }[5m]
+          )
+        ) by (le))
+    |||,
     legendFormat='50th percentile'
   ),
 ]);


### PR DESCRIPTION
It's a long running connection kept open, serving progressbar responses via
[EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource). So it can't be treated as a regular HTTP request / response.

Getting rid of this unmasks more real problems in hub response latency by removing this noise.

Ref https://github.com/2i2c-org/infrastructure/issues/2127#issuecomment-1426182346