### PR TITLE
Add dashboard for per-user pod diagnostics

### DIFF
--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -1,0 +1,105 @@
+#!/usr/bin/env jsonnet -J ../vendor
+// Deploys one dashboard - "JupyterHub dashboard",
+// with useful stats about usage & diagnostics.
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local singlestat = grafana.singlestat;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+local template = grafana.template;
+local tablePanel = grafana.tablePanel;
+local row = grafana.row;
+local heatmapPanel = grafana.heatmapPanel;
+
+local jupyterhub = import 'jupyterhub.libsonnet';
+local standardDims = jupyterhub.standardDims;
+
+local templates = [
+  template.datasource(
+    name='PROMETHEUS_DS',
+    query='prometheus',
+    current=null,
+    hide='label',
+  ),
+  template.new(
+    'hub',
+    datasource='$PROMETHEUS_DS',
+    query='label_values(kube_service_labels{service="hub"}, namespace)',
+    // Allow viewing dashboard for multiple combined hubs
+    includeAll=true,
+    multi=true
+  ),
+  template.new(
+    'user_pod',
+    datasource='$PROMETHEUS_DS',
+    query='label_values(kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub"}, pod)',
+    // Allow viewing dashboard for multiple users
+    includeAll=true,
+    multi=true
+  ),
+];
+
+
+local memoryUsage = graphPanel.new(
+  'Memory Usage',
+  description=|||
+    Per-user per-server memory usage
+  |||,
+  formatY1='bytes',
+  datasource='$PROMETHEUS_DS'
+).addTarget(
+  prometheus.target(
+    |||
+      sum(
+        # exclude name="" because the same container can be reported
+        # with both no name and `name=k8s_...`,
+        # in which case sum() by (pod) reports double the actual metric
+        container_memory_working_set_bytes{name!=""}
+        * on (namespace, pod) group_left(container) 
+        group(
+            kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}
+        ) by (pod, namespace)
+      ) by (pod)
+    |||,
+    legendFormat='{{ pod }} - ({{ namespace }})'
+  ),
+);
+
+local cpuUsage = graphPanel.new(
+  'CPU Usage',
+  description=|||
+    Per-user per-server CPU usage
+  |||,
+  formatY1='percentunit',
+  datasource='$PROMETHEUS_DS'
+).addTarget(
+  prometheus.target(
+    |||
+      sum(
+        # exclude name="" because the same container can be reported
+        # with both no name and `name=k8s_...`,
+        # in which case sum() by (pod) reports double the actual metric
+        irate(container_cpu_usage_seconds_total{name!=""}[5m])
+        * on (namespace, pod) group_left(container) 
+        group(
+            kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}
+        ) by (pod, namespace)
+      ) by (pod)
+    |||,
+    legendFormat='{{ pod }} - ({{ namespace }})'
+  ),
+);
+
+
+dashboard.new(
+  'User Pod Diagnostics Dashboard',
+  tags=['jupyterhub'],
+  uid='user-pod-diagnostics-dashboard',
+  editable=true
+).addTemplates(
+  templates
+).addPanel(
+  memoryUsage, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
+).addPanel(
+  cpuUsage, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
+)

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -1,6 +1,4 @@
 #!/usr/bin/env jsonnet -J ../vendor
-// Deploys one dashboard - "JupyterHub dashboard",
-// with useful stats about usage & diagnostics.
 local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local singlestat = grafana.singlestat;


### PR DESCRIPTION
"My kernel is crashing" is one of the most common
complaints when supporting users on a JupyterHub, and figuring out 'how much memory is the user who has problems using?' is the primary diagnostic step. This commit adds a dashboard that lets us answer that question for memory & CPU very easily.

This is specific to user *pods*, so each user server in a hub with many named servers will get its own entry.