### PR TITLE
Allow filtering user pod diagnostics by node & add resource guarantee panels

### DIFF
--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -101,10 +101,10 @@ local cpuUsage = graphPanel.new(
   ),
 );
 
-local memoryGuarantee = graphPanel.new(
-  'Memory Guarante',
+local memoryRequests = graphPanel.new(
+  'Memory Requests',
   description=|||
-    Per-user per-server memory guarantee
+    Per-user per-server memory Requests
   |||,
   formatY1='bytes',
   datasource='$PROMETHEUS_DS'
@@ -119,10 +119,10 @@ local memoryGuarantee = graphPanel.new(
   ),
 );
 
-local cpuGuarantee = graphPanel.new(
-  'CPU Guarantee',
+local cpuRequests = graphPanel.new(
+  'CPU Requests',
   description=|||
-    Per-user per-server CPU Guarantee
+    Per-user per-server CPU Requests
   |||,
   formatY1='percentunit',
   datasource='$PROMETHEUS_DS'
@@ -148,7 +148,7 @@ dashboard.new(
 ).addPanel(
   cpuUsage, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
 ).addPanel(
-  memoryGuarantee, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
+  memoryRequests, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
 ).addPanel(
-  cpuGuarantee, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
+  cpuRequests, { h: standardDims.h * 1.5, w: standardDims.w * 2 }
 )

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -35,6 +35,14 @@ local templates = [
     includeAll=true,
     multi=true
   ),
+  template.new(
+    'instance',
+    datasource='$PROMETHEUS_DS',
+    query='label_values(kube_node_info, node)',
+    // Allow viewing dashboard for multiple nodes
+    includeAll=true,
+    multi=true
+  ),
 ];
 
 
@@ -52,7 +60,7 @@ local memoryUsage = graphPanel.new(
         # exclude name="" because the same container can be reported
         # with both no name and `name=k8s_...`,
         # in which case sum() by (pod) reports double the actual metric
-        container_memory_working_set_bytes{name!=""}
+        container_memory_working_set_bytes{name!="", instance=~"$instance"}
         * on (namespace, pod) group_left(container) 
         group(
             kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}
@@ -77,7 +85,7 @@ local cpuUsage = graphPanel.new(
         # exclude name="" because the same container can be reported
         # with both no name and `name=k8s_...`,
         # in which case sum() by (pod) reports double the actual metric
-        irate(container_cpu_usage_seconds_total{name!=""}[5m])
+        irate(container_cpu_usage_seconds_total{name!="", instance=~"$instance"}[5m])
         * on (namespace, pod) group_left(container) 
         group(
             kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -36,11 +36,11 @@ local templates = [
     multi=true
   ),
   template.new(
-    # Queries should use the 'instance' label when querying metrics that
-    # come from collectors present on each node - such as node_exporter or
-    # container_ metrics, and use the 'node' label when querying metrics
-    # that come from collectors that are present once per cluster, like
-    # kube_state_metrics.
+    // Queries should use the 'instance' label when querying metrics that
+    // come from collectors present on each node - such as node_exporter or
+    // container_ metrics, and use the 'node' label when querying metrics
+    // that come from collectors that are present once per cluster, like
+    // kube_state_metrics.
     'instance',
     datasource='$PROMETHEUS_DS',
     query='label_values(kube_node_info, node)',


### PR DESCRIPTION
- Per node filter is very helpful when diagnosing node falures
- Added panels for cpu and memory guarantees provided

Inspired by debugging https://github.com/2i2c-org/infrastructure/issues/2430