### PR TITLE
adding an additional 25th percentage spawn launch timer

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -237,6 +237,24 @@ local hubResponseLatency = graphPanel.new(
     |||,
     legendFormat='50th percentile'
   ),
+  prometheus.target(
+    |||
+      histogram_quantile(
+        0.25,
+        sum(
+          rate(
+            jupyterhub_request_duration_seconds_bucket{
+              app="jupyterhub",
+              namespace=~"$hub",
+              # Ignore SpawnProgressAPIHandler, as it is a EventSource stream
+              # and keeps long lived connections open
+              handler!="jupyterhub.apihandlers.users.SpawnProgressAPIHandler"
+            }[5m]
+          )
+        ) by (le))
+    |||,
+    legendFormat='25th percentile'
+  ),
 ]);
 
 


### PR DESCRIPTION
after adding additional buckets > 2 minutes (https://github.com/jupyterhub/jupyterhub/issues/4351 and https://github.com/jupyterhub/jupyterhub/pull/4352), i noticed that the grafana panel was still not really providing useful information.  pictures speak louder than words:  
<img width="460" alt="image" src="https://user-images.githubusercontent.com/1606572/230453651-021800bd-9a2c-4027-b692-ed2c50949704.png">

so, i added another query in our local deployment that displayed the 25th percentile, in addition to 50th and 99th.  this (AFAICT) is giving us a more accurate picture of how long it takes for the vast majority of servers to spawn:  
<img width="462" alt="image" src="https://user-images.githubusercontent.com/1606572/230453981-2668c099-eba2-46df-ae98-5607ea07844f.png">

however, i'm still not sure about the accuracy of the 99th percentile...  i did a bunch of testing by delaying the server spawn by up to 5m, and the 99th percentile immediately went up to 10m:  
<img width="757" alt="spawn-launcher-delay-testing" src="https://user-images.githubusercontent.com/1606572/230455936-a44a934c-83b5-4c28-b5a0-ca7913691a9d.png">


i am dubious about the accuracy/relevance of the 99th percentile being included in this panel, but i feel that's out of scope for this PR.

@yuvipanda 