### PR TITLE
Add panel for monitoring per-user directory size

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,91 @@ spec:
 ```
 
 You will likely only need to adjust the `claimName` above to use this example.
+
+
+### Per-user home directory metrics (size, last modified, total entries, etc)
+
+When using a shared home directory for users, it is helpful to collect information
+on each user's home directory - total size, last time any files within it were
+modified, etc. This helps notice when a single user is using a lot of space,
+often accidentally! The [prometheus-dirsize-exporter](https://github.com/yuvipanda/prometheus-dirsize-exporter)
+can be deployed to collect this information efficiently for querying. Here is
+an example YAML for deployment:
+
+```yaml
+# To provide data for the jupyterhub/grafana-dashboards dashboard about per-user
+# home directories in the shared volume, which contains users home folders etc, we deploy
+# prometheus node-exporter to collect this data for prometheus server to scrape.
+#
+# This is based on the Deployment manifest in jupyterhub/grafana-dashboards'
+# readme: https://github.com/jupyterhub/grafana-dashboards#additional-collectors
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shared-dirsize-metrics
+  labels:
+    app: jupyterhub
+    component: shared-dirsize-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: shared-dirsize-metrics
+  template:
+    metadata:
+      annotations:
+        # This enables prometheus to actually scrape metrics from here
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+      labels:
+        app: jupyterhub
+        component: shared-dirsize-metrics
+    spec:
+      containers:
+        - name: dirsize-exporter
+          # From https://github.com/yuvipanda/prometheus-dirsize-exporter
+          image: quay.io/yuvipanda/prometheus-dirsize-exporter:v1.2
+          resources:
+            # Provide *very few* resources for this collector, as it can
+            # baloon up (especially in CPU) quite easily. We are quite ok with
+            # the collection taking a while as long as we aren't costing too much
+            # CPU or RAM
+            requests:
+              memory: 16Mi
+              cpu: 0.01
+            limits:
+              cpu: 0.05
+              memory: 128Mi
+          command:
+            - dirsize-exporter
+            - /shared-volume
+            - "250" # Use only 250 io operations per second at most
+            - "120" # Wait 2h between runs
+            - --port=8000
+          ports:
+            - containerPort: 8000
+              name: dirsize-metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 0
+            runAsUser: 1000
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /shared-volume
+              readOnly: true
+      securityContext:
+        fsGroup: 65534
+      volumes:
+        # This is the volume that we will mount and monitor. You should reference
+        # a shared volume containing home directories etc. This is often a PVC
+        # bound to a PV referencing a NFS server.
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: home-nfs
+
+```
+
+You will likely only need to adjust the `claimName` above to use this example.


### PR DESCRIPTION
Monitoring each user's home directory size is an often requested feature for z2jh, and kinda important to prevent disk space related outages when using shared clusters. A single user can easily accidentally take up the space of an entire NFS share, and without an easy way to monitor this, can be hard to let them know before the disk is full.

Admins could manually run `du` on an NFS server now and then, but this is time consuming and error prone. This also can hammer the server hard - millions of IO operations are performed as pretty much each file must be touched to calculate directory sizes.

https://github.com/yuvipanda/prometheus-dirsize-exporter does this efficiently, primarily by allowing you to throttle how much IO operations per second it can make. This prevents the NFS server from being unsuable due to IO saturation, instead trading off latency of how up to date these stats are. As we don't need upto the minute stats here, this is acceptable.

Test deployment at https://github.com/2i2c-org/infrastructure/pull/2621

Example:

<img width="1713" alt="image" src="https://github.com/jupyterhub/grafana-dashboards/assets/30430/275dec49-7d14-4bef-8804-a5d31ef52582">
