### PR TITLE
Fix CPU & memory component graphs

### DIFF
--- a/dashboards/jupyterhub.libsonnet
+++ b/dashboards/jupyterhub.libsonnet
@@ -21,7 +21,7 @@ local prometheus = grafana.prometheus;
   componentLabel(component, cmp='=', namespace='$hub')::
     std.format(
       // group aggregator is used to ensure named pods are unique per namespace
-      '\n  group(\n    kube_pod_labels{label_app="jupyterhub", label_component%s"%s"%s}\n  ) by (pod%s)',
+      '\n  group(\n    kube_pod_labels{label_app="jupyterhub", label_component%s"%s"%s}\n  ) by (label_component, pod%s)',
       [
         cmp,
         component,


### PR DESCRIPTION
Without this, all cpu and memory components are collapsed into a single value.

Without this:

<img width="859" alt="image" src="https://github.com/jupyterhub/grafana-dashboards/assets/30430/1c8bc25c-22c6-40b1-a57e-877b7dbb6db1">

With:

<img width="857" alt="image" src="https://github.com/jupyterhub/grafana-dashboards/assets/30430/5fbea60d-f72a-411b-921f-5aff2a875237">

Fixes https://github.com/jupyterhub/grafana-dashboards/issues/44