### PR TITLE
Add graph with requests by status code

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -257,6 +257,27 @@ local hubResponseLatency = graphPanel.new(
   ),
 ]);
 
+local hubResponseCodes = graphPanel.new(
+  'Hub response status codes',
+  min=0,
+  datasource='$PROMETHEUS_DS'
+).addTargets([
+  prometheus.target(
+    |||
+      sum(
+        increase(
+          jupyterhub_request_duration_seconds_bucket{
+            app="jupyterhub",
+            namespace=~"$hub",
+          }[2m]
+        )
+      ) by (code)
+    |||,
+    legendFormat='{{ code }}'
+  ),
+]);
+
+
 
 // with multi=true, component='singleuser-server' means all components *except* singleuser-server
 local allComponentsMemory = jupyterhub.memoryPanel('All JupyterHub Components', component='singleuser-server', multi=true);
@@ -539,6 +560,8 @@ dashboard.new(
   serverSpawnFailures, {}
 ).addPanel(
   hubResponseLatency, {}
+).addPanel(
+  hubResponseCodes, {}
 ).addPanel(
   allComponentsCPU, { h: standardDims.h * 1.5 },
 ).addPanel(

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -278,7 +278,6 @@ local hubResponseCodes = graphPanel.new(
 ]);
 
 
-
 // with multi=true, component='singleuser-server' means all components *except* singleuser-server
 local allComponentsMemory = jupyterhub.memoryPanel('All JupyterHub Components', component='singleuser-server', multi=true);
 local allComponentsCPU = jupyterhub.cpuPanel('All JupyterHub Components', component='singleuser-server', multi=true);


### PR DESCRIPTION
Watching for 5xx, 4xx errors is very helpful when looking for JupyterHub issues. Also helps us validate that things are getting better after fixes.

Looks like this:

<img width="1314" alt="image" src="https://github.com/jupyterhub/grafana-dashboards/assets/30430/85a29c62-c0c8-4438-8b9b-330c2c33f7bb">
