### PR TITLE
Add basic sphinx based documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+docs/_build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,7 @@
+# Configuration on how ReadTheDocs (RTD) builds our documentation
+# ref: https://readthedocs.org/projects/jupyterhub-grafana/
+# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
 version: 2
 
 build:

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -159,7 +159,7 @@ local cpuRequests = graphPanel.new(
 );
 
 dashboard.new(
-  'User Pod Diagnostics Dashboard',
+  'User Diagnostics Dashboard',
   tags=['jupyterhub'],
   uid='user-pod-diagnostics-dashboard',
   editable=true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,35 @@
+project = 'JupyterHub Grafana Dashboards'
+copyright = '2023, Project Jupyter Contributors'
+author = 'Project Jupyter Contributors'
+
+
+extensions = [
+    "myst_parser",
+]
+
+myst_enable_extensions = [
+    "deflist",
+    "colon_fence",
+]
+
+source_suffix = [".rst", ".md"]
+
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_book_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,70 @@
+# Contributing
+
+## Upgrading grafonnet version
+
+The grafonnet jsonnet library is bundled here with [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler).
+Just running `jb update` in the git repo root dir after installing jsonnet-bunder should bring
+you up to speed.
+
+## Metrics guidelines
+
+Interpreting prometheus metrics and writing PromQL queries that serve a particular
+purpose can be difficult. Here are some guidelines to help.
+
+### Container memory usage metric
+
+"When will the OOM killer start killing processes in this container?" is the most useful
+thing for us to know when measuring container memory usage. Of the many container memory
+metrics, `container_memory_working_set_bytes` tracks this (see [this blog post](https://faun.pub/how-much-is-too-much-the-linux-oomkiller-and-used-memory-d32186f29c9d)
+and [this issue](https://github.com/jupyterhub/grafana-dashboards/issues/13)).
+So prefer using that metric as the default for 'memory usage' unless specific reasons
+exist for using a different metric.
+
+### Available metrics
+
+The most common prometheus on kubernetes setup in the JupyterHub community seems
+to be the [prometheus helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus).
+
+
+1. [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
+   ([metrics documentation](https://github.com/kubernetes/kube-state-metrics/tree/master/docs))
+   collects information about various kubernetes objects (pods, services, etc)
+   by scraping the kubernetes API. Anything you can get via `kubectl` commands,
+   you can probably get via a metric here. Very helpful as a way to query other
+   metrics based on the kubernetes object they represent (like pod, node, etc).
+
+2. [node-exporter](https://github.com/prometheus/node_exporter)
+   ([metrics documentation](https://github.com/prometheus/node_exporter#enabled-by-default))
+   collects information about each node - CPU usage, memory, disk space, etc. Since hostnames
+   are usually random, you usually join these metrics with `kube-state-metrics` node
+   metrics to get useful information out. If you are running a manual NFS server,
+   it is recommended to run a node-exporter instance there as well to collect server
+   metrics.
+
+3. [cadvisor](https://github.com/google/cadvisor)
+   ([metrics documentation](https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md))
+   collects information about each *container*. Join these with pod metrics from
+   `kube-state-metrics` for useful queries.
+
+4. [jupyterhub](https://jupyterhub.readthedocs.io/en/latest/)
+   ([metrics documentation](https://jupyterhub.readthedocs.io/en/latest/reference/metrics.html))
+   collects information directly from the JupyterHubs.
+
+5. Other components you have installed on your cluster - like prometheus,
+   nginx-ingress, etc - will also emit their own metrics.
+
+### Avoid double-counting container metrics
+
+It seems that one container's resource metrics can be reported multiple times,
+with an empty `name` label and a `name=k8s_...` label.
+Because of this, if we do `sum(container_resource_metric) by (pod)`,
+we will often get twice the actual resource consumption of a given pod.
+Since `name=""` is always redundant, make sure to exclude this in any query
+that includes a sum across container metrics.
+For example:
+
+```promql
+sum(
+    irate(container_cpu_usage_seconds_total{name!=""}[5m])
+) by (namespace, pod)
+```

--- a/docs/howto/deploy.md
+++ b/docs/howto/deploy.md
@@ -135,6 +135,7 @@ spec:
 You will likely only need to adjust the `claimName` above to use this example.
 
 
+(howto:deploy:per-user-home-dir)=
 ### Per-user home directory metrics (size, last modified, total entries, etc)
 
 When using a shared home directory for users, it is helpful to collect information

--- a/docs/howto/deploy.md
+++ b/docs/howto/deploy.md
@@ -1,0 +1,252 @@
+# How to deploy the dashboards
+ 
+```{warning}
+ANY CHANGES YOU MAKE VIA THE GRAFANA UI WILL BE OVERWRITTEN NEXT TIME YOU RUN deploy.bash.
+TO MAKE CHANGES, EDIT THE JSONNET FILE AND DEPLOY AGAIN
+```
+
+## Pre-requisites
+
+1. Locally, you need to have
+   [jsonnet](https://github.com/google/jsonnet#packages) installed.  The
+   [grafonnet](https://grafana.github.io/grafonnet-lib/) library is already
+   vendored in, using
+   [jsonnet-builder](https://github.com/jsonnet-bundler/jsonnet-bundler).
+
+2. A recent version of prometheus installed on your cluster. Currently, it is assumed that your prometheus instance
+   is installed using the [prometheus helm
+   chart](https://github.com/prometheus-community/helm-charts), with
+   [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics),
+   [node-exporter](https://github.com/prometheus/node_exporter) and
+   [cadvisor](https://github.com/google/cadvisor) enabled. In
+   addition, you should scrape metrics from the hub instance as well.
+   
+   
+    ```{tip}
+    If you're using a prometheus chart older than version `14.*`, then you can deploy the dashboards available prior to the upgrade, in the [`1.0 tag`](https://github.com/jupyterhub/grafana-dashboards/releases/tag/1.0).
+    ```
+   
+3. `kube-state-metrics` must be configured to add some labels to metrics 
+   [since version 2.0](https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/).
+   If deployed with the prometheus helm chart, the config should look like this:
+   
+   ```yaml
+   kube-state-metrics:
+      metricLabelsAllowlist:
+         # to select jupyterhub component pods and get the hub usernames
+         - pods=[app,component,hub.jupyter.org/username]
+         # allowing all labels is probably fine for nodes, since they don't churn much, unlike pods
+         - nodes=[*]
+   ```
+   
+   ```{tip}
+   Make sure this is indented correctly where it should be!
+   ```
+
+4. A recent version of Grafana, with a prometheus data source already added.
+
+5. An API key with 'admin' permissions. This is per-organization, and you can make a new one
+   by going to the configuration pane for your Grafana (the gear icon on the left bar), and
+   selecting 'API Keys'. The admin permission is needed to query list of data sources so we
+   can auto-populate template variable options (such as list of hubs).
+
+
+## Additional prometheus exporters
+
+Some very useful metrics (such as home directory free space) require
+additional collectors to be installed in your cluster, customized to your
+needs.
+
+### Free space (%) in shared volume (Home directories, etc.)
+
+In many common z2jh configurations, home directories are setup via a shared
+filesystem (like NFS, AzureFile, etc). You can grab additional metrics by
+a deployment of [prometheus node_exporter](https://prometheus.io/docs/guides/node-exporter/),
+collecting just the filesystem metrics. Here is an example deployment YAML:
+
+```yaml
+# To provide data for the jupyterhub/grafana-dashboards dashboard about free
+# space in the shared volume, which contains users home folders etc, we deploy
+# prometheus node-exporter to collect this data for prometheus server to scrape.
+#
+# This is based on the Deployment manifest in jupyterhub/grafana-dashboards'
+# readme: https://github.com/jupyterhub/grafana-dashboards#additional-collectors
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jupyterhub
+    component: shared-volume-metrics
+  name: shared-volume-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: shared-volume-metrics
+  template:
+    metadata:
+      annotations:
+        # This enables prometheus to actually scrape metrics from here
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+      labels:
+        app: jupyterhub
+        # The component label below should match a grafana dashboard definition
+        # in jupyterhub/grafana-dashboards, do not change it!
+        component: shared-volume-metrics
+    spec:
+      containers:
+      - name: shared-volume-exporter
+        image: quay.io/prometheus/node-exporter:v1.5.0
+        args:
+          # We only want filesystem stats
+          - --collector.disable-defaults
+          - --collector.filesystem
+          - --web.listen-address=:9100
+        ports:
+          - containerPort: 9100
+            name: metrics
+            protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+        volumeMounts:
+          - name: shared-volume
+            # Mounting under /shared-volume is important as we reference this
+            # path in our dashboard definition.
+            mountPath: /shared-volume
+            # Mount it readonly to prevent accidental writes
+            readOnly: true
+      securityContext:
+        fsGroup: 65534
+      volumes:
+        # This is the volume that we will mount and monitor. You should reference
+        # a shared volume containing home directories etc. This is often a PVC
+        # bound to a PV referencing a NFS server.
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: home-nfs
+```
+
+You will likely only need to adjust the `claimName` above to use this example.
+
+
+### Per-user home directory metrics (size, last modified, total entries, etc)
+
+When using a shared home directory for users, it is helpful to collect information
+on each user's home directory - total size, last time any files within it were
+modified, etc. This helps notice when a single user is using a lot of space,
+often accidentally! The [prometheus-dirsize-exporter](https://github.com/yuvipanda/prometheus-dirsize-exporter)
+can be deployed to collect this information efficiently for querying. Here is
+an example YAML for deployment:
+
+```yaml
+# To provide data for the jupyterhub/grafana-dashboards dashboard about per-user
+# home directories in the shared volume, which contains users home folders etc, we deploy
+# prometheus node-exporter to collect this data for prometheus server to scrape.
+#
+# This is based on the Deployment manifest in jupyterhub/grafana-dashboards'
+# readme: https://github.com/jupyterhub/grafana-dashboards#additional-collectors
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shared-dirsize-metrics
+  labels:
+    app: jupyterhub
+    component: shared-dirsize-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: shared-dirsize-metrics
+  template:
+    metadata:
+      annotations:
+        # This enables prometheus to actually scrape metrics from here
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+      labels:
+        app: jupyterhub
+        component: shared-dirsize-metrics
+    spec:
+      containers:
+        - name: dirsize-exporter
+          # From https://github.com/yuvipanda/prometheus-dirsize-exporter
+          image: quay.io/yuvipanda/prometheus-dirsize-exporter:v1.2
+          resources:
+            # Provide *very few* resources for this collector, as it can
+            # baloon up (especially in CPU) quite easily. We are quite ok with
+            # the collection taking a while as long as we aren't costing too much
+            # CPU or RAM
+            requests:
+              memory: 16Mi
+              cpu: 0.01
+            limits:
+              cpu: 0.05
+              memory: 128Mi
+          command:
+            - dirsize-exporter
+            - /shared-volume
+            - "250" # Use only 250 io operations per second at most
+            - "120" # Wait 2h between runs
+            - --port=8000
+          ports:
+            - containerPort: 8000
+              name: dirsize-metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 0
+            runAsUser: 1000
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /shared-volume
+              readOnly: true
+      securityContext:
+        fsGroup: 65534
+      volumes:
+        # This is the volume that we will mount and monitor. You should reference
+        # a shared volume containing home directories etc. This is often a PVC
+        # bound to a PV referencing a NFS server.
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: home-nfs
+
+```
+
+You will likely only need to adjust the `claimName` above to use this example.
+
+
+## Deploy the dashbaords
+
+There's a helper `deploy.py` script that can deploy the dashboards to any grafana installation.
+
+```bash
+export GRAFANA_TOKEN="<API-TOKEN-FOR-YOUR-GRAFANA>
+./deploy.py <your-grafana-url>
+```
+
+This creates a folder called 'JupyterHub Default Dashboards' in your grafana, and adds
+a couple of dashboards to it.
+
+If your Grafana deployment supports more than one datasource, then apart from the default dashboards in the [`dashboards` directory](https://github.com/jupyterhub/grafana-dashboards/tree/main/dashboards), you should also consider deploying apart the dashboards in [`global-dashboards` directory](https://github.com/jupyterhub/grafana-dashboards/tree/main/global-dashboards).
+
+```bash
+export GRAFANA_TOKEN="<API-TOKEN-FOR-YOUR-GRAFANA>
+./deploy.py <your-grafana-url> --dashboards-dir global-dashboards
+```
+
+The global dashboards will use the list of available dashboards in your Grafana provided to them and will build dashboards across all of them.
+
+If your Grafana instance uses a self-signed certificate, use the `--no-tls-verify` flag when executing the `deploy.py` script. For example:
+
+```bash
+./deploy.py <your-grafana-url> --no-tls-verify
+```
+

--- a/docs/howto/user-diagnostics.md
+++ b/docs/howto/user-diagnostics.md
@@ -1,0 +1,24 @@
+# Look at individual user metrics
+
+A common support request for JupyterHub admins pertains to specific issues
+faced by a particular user. The "User Diagnostics" dashboard helps with this.
+It also helps look for *outliers* in a hub - people using too much of a particular
+resource, or not enough of a particular resource.
+
+## Home directory size (with shared volumes)
+
+If you use a shared volume (such as NFS) for home directory storage, you can
+use the [prometheus-dirsize-exporter](https://github.com/yuvipanda/prometheus-dirsize-exporter)
+to efficiently collect information about the *size* of each user's home directory.
+Once [deployed](howto:deploy:per-user-home-dir), the exporter will collect slowly
+collect informatiohn about the size of each user's home directory and make that
+available to prometheus. The "Home directory usage (on shared home directories)"
+graph will display this over time.
+
+```{note}
+The exporter is optimized to use as few IOPS as possible, to make sure we do
+not reduce performance for end users actually using the home directories to store
+stuff. As a result, the sizes will probably be out of date and take a while to
+update, depending on how big the home directories are. Use these for general
+monitoring, nothing realtime.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-# Grafana Dashboards for JupyterHub
+# Welcome to JupyterHub Grafana Dashboards's documentation!
 
 Grafana Dashboards for use with [Zero to JupyterHub on Kubernetes](http://z2jh.jupyter.org/)
 
-![Grafana Dasboard Screencast](demo.gif)
+![Grafana Dasboard Screencast](../demo.gif)
 
 ## What?
 
@@ -16,6 +16,17 @@ to help with this. It uses [jsonnet](https://jsonnet.org/) and
 [grafonnet](https://github.com/grafana/grafonnet-lib) to generate dashboards completely
 via code. This can then be deployed on any Grafana instance!
 
-## Deployment
+## How-to
 
-Deployment instructions are available in the documentation.
+```{toctree}
+:maxdepth: 2
+howto/deploy.md
+```
+
+## Contributing
+
+```{toctree}
+:maxdepth: 2
+contributing.md
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ via code. This can then be deployed on any Grafana instance!
 ```{toctree}
 :maxdepth: 2
 howto/deploy.md
+howto/user-diagnostics.md
 ```
 
 ## Contributing

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+myst-parser[sphinx,linkify]
+sphinx-book-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-sphinx
-myst-parser[sphinx,linkify]
+myst-parser[linkify]
 sphinx-book-theme


### PR DESCRIPTION
- Move most info from README (which was getting long) to documentation site. Once RTD is set up, I'll link to that from the README.
- Add a tiny bit of docs on shared home directory sizes. We should work on adding more docs over time.