### PR TITLE
Add graph to measure images used by user pods

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -525,6 +525,28 @@ local highMemoryUsagePods = tablePanel.new(
   ),
 ]).hideColumn('Time');
 
+# Show images used by different users on the hub
+local notebookImagesUsed = graphPanel.new(
+  'Images used by user pods',
+  description=|||
+    Number of user servers using a container image
+  |||,
+  legend_hideZero=false,
+  decimals=0,
+  stack=true,
+  min=0,
+  datasource='$PROMETHEUS_DS'
+).addTargets([
+  prometheus.target(
+    |||
+      sum (
+        # User pods are named "notebook" by kubespawner
+        kube_pod_container_info{container="notebook", namespace=~"$hub"}
+      ) by(image_spec, namespace)
+    |||,
+    legendFormat='{{image_spec}} (prod)',
+  ),
+]);
 
 dashboard.new(
   'JupyterHub Dashboard',
@@ -543,6 +565,10 @@ dashboard.new(
   weeklyActiveUsers, {}
 ).addPanel(
   monthlyActiveUsers, {}
+).addPanel(
+  row.new('Container Images'), {},
+).addPanel(
+  notebookImagesUsed, {}
 ).addPanel(
   row.new('User Resource Utilization stats'), {}
 ).addPanel(

--- a/docs/howto/images.md
+++ b/docs/howto/images.md
@@ -1,0 +1,9 @@
+# Find what images users are using
+
+With kubespawner's `profileList` feature, end users may choose different
+images to launch. It is useful to measure what images are being used so we
+can serve our users better over time.
+
+The "Images used by user pods" graph in the JupyterHub dashboard helps with this.
+It shows the popularity of various images used over time. Note that if an image
+is no used at all, it will not be shown.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ via code. This can then be deployed on any Grafana instance!
 :maxdepth: 2
 howto/deploy.md
 howto/user-diagnostics.md
+howto/images.md
 ```
 
 ## Contributing


### PR DESCRIPTION
With KubeSpawner's profileList, users may use different images when starting their servers. Measuring and displaying this helps admins know which images are popular, and help support users more.

This becomes more relevant with
https://github.com/jupyterhub/kubespawner/pull/735, as end users can now specify arbitrary images.

Added some docs along with this!

Query thanks to @pnasrat, from
https://github.com/2i2c-org/infrastructure/issues/2582#issuecomment-1568366834