### PR TITLE
update non running pods panel title verbiage to be more clear

### DIFF
--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -324,7 +324,7 @@ local nodeOOMKills = graphPanel.new(
 ]);
 
 local nonRunningPods = graphPanel.new(
-  'Non Running Pods',
+  'Pods not in Running state',
   description=|||
     Pods in states other than 'Running'.
 


### PR DESCRIPTION
the title is a bit misleading, and that little 'info' icon next to it is tiny and easily overlooked.  renaming this panel should help clarify what it's reporting.