### PR TITLE
Explicitly set `allValues` for hub variable

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -28,7 +28,10 @@ local templates = [
     // Allow viewing dashboard for multiple combined hubs
     includeAll=true,
     multi=true
-  ),
+  ) + {
+    // Explicitly set '$hub' to be `.*` when 'All' is selected, as we always use `$hub` as a regex
+    allValue: '.*',
+  },
 ];
 
 

--- a/dashboards/usage-report.jsonnet
+++ b/dashboards/usage-report.jsonnet
@@ -18,7 +18,10 @@ local templates = [
     // Allow viewing dashboard for multiple combined hubs
     includeAll=true,
     multi=false
-  ),
+  ) + {
+    // Explicitly set '$hub' to be `.*` when 'All' is selected, as we always use `$hub` as a regex
+    allValue: '.*',
+  },
 ];
 
 local memoryUsageUserPods = barGaugePanel.new(

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -26,7 +26,10 @@ local templates = [
     // Allow viewing dashboard for multiple combined hubs
     includeAll=true,
     multi=true
-  ),
+  ) + {
+    // Explicitly set '$hub' to be `.*` when 'All' is selected, as we always use `$hub` as a regex
+    allValue: '.*',
+  },
   template.new(
     'user_pod',
     datasource='$PROMETHEUS_DS',


### PR DESCRIPTION
Currently, on latest grafana, the dashboards will currently show 'no data' because the `$hub` variable is not set correctly (see https://github.com/2i2c-org/infrastructure/issues/3237 for details). The longer term solution to this is:

1. Move away from the deprecated graphPanel to timeseries objects for panel
2. https://github.com/jupyterhub/grafana-dashboards/issues/89

Both of these are being undertaken in
https://github.com/jupyterhub/grafana-dashboards/pull/90, but in the meantime, this PR implements
[this
workaround](https://github.com/jupyterhub/grafana-dashboards/pull/90) so end users can at least see data.