### PR TITLE
Remove unused function parameter global_dash

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -47,8 +47,7 @@ def ensure_folder(name, uid, api):
             raise
 
 
-def build_dashboard(dashboard_path, api, global_dash=False):
-
+def build_dashboard(dashboard_path, api):
     datasources = api("/datasources")
     datasources_names = [ds["name"] for ds in datasources]
 
@@ -99,8 +98,8 @@ def layout_dashboard(dashboard):
     return dashboard
 
 
-def deploy_dashboard(dashboard_path, folder_uid, api, global_dash=False):
-    db = build_dashboard(dashboard_path, api, global_dash)
+def deploy_dashboard(dashboard_path, folder_uid, api):
+    db = build_dashboard(dashboard_path, api)
 
     if not db:
         return


### PR DESCRIPTION
When learning on how to deploy the global dashboards through code inspection, this unused parameter caused confusion for me.

I figure this shouldn't be considered breaking as we aren't version controlling things in this repo, and I think this could be considered internal since the main use of this function is internal by the CLI application defined in deploy.py

## Test failures are unrelated

Test failures are from the main branch as well by recent addition #107.