### PR TITLE
Add test to render and lint dashboards

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/grafana-dashboards/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: /
+    labels: [ci]
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,16 +27,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jsonnet-version: [latest]
+        jsonnet-version: ["0.20.0"]
 
     steps:
       - uses: actions/checkout@v4
 
-      # Based on https://github.com/zendesk/setup-jsonnet/blob/master/install-jsonnet.sh
-      - name: Install jsonnet (go-jsonnet)
+      - name: Download jsonnet (go-jsonnet)
         run: |
-          go install "github.com/google/go-jsonnet/cmd/jsonnet@${{ matrix.jsonnet-version }}"
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          JSONNET_VERSION=${{ matrix.jsonnet-version }}
+          wget -qO- https://github.com/google/go-jsonnet/releases/download/v${JSONNET_VERSION}/go-jsonnet_${JSONNET_VERSION}_Linux_x86_64.tar.gz \
+              | tar -xvz --one-top-level=$HOME/.local/bin
 
       - run: jsonnet --version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,104 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/*.yaml"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  render-dashboards:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        jsonnet-version: [latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Based on https://github.com/zendesk/setup-jsonnet/blob/master/install-jsonnet.sh
+      - name: Install jsonnet (go-jsonnet)
+        run: |
+          go install "github.com/google/go-jsonnet/cmd/jsonnet@${{ matrix.jsonnet-version }}"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - run: jsonnet --version
+
+      - name: Render dashboards
+        run: |
+          mkdir rendered-dashboards
+          dashboard_folders="dashboards global-dashboards"
+          for file in `find $dashboard_folders -name '*.jsonnet'`
+          do
+              jsonnet -J vendor --tla-code 'datasources=["prometheus-test"]' --output-file rendered-dashboards/`basename $file` $file
+          done
+
+      - name: Upload rendered dashboards
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendered-dashboards-${{ github.run_attempt }}
+          path: ./rendered-dashboards
+
+  lint-dashboards:
+    runs-on: ubuntu-22.04
+    needs: [render-dashboards]
+
+    steps:
+      - name: Download rendered dashboards
+        uses: actions/download-artifact@v4
+        with:
+          name: rendered-dashboards-${{ github.run_attempt }}
+          path: ./rendered-dashboards
+
+      - name: Install dashboard-linter
+        run: |
+          go install github.com/grafana/dashboard-linter@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      - name: dashboard-linter rules
+        run: |
+          echo "Available rules are documented in https://github.com/grafana/dashboard-linter/blob/main/docs/index.md#rules"
+          echo ""
+          dashboard-linter rules
+
+      - name: dashboard-linter lint
+        run: |
+          lint_failures=""
+
+          dashboard_folders=rendered-dashboards
+          for file in `find $dashboard_folders -name '*.jsonnet'`
+          do
+              lint_fail=""
+              echo "::group::$file"
+              dashboard-linter lint --strict $file || lint_fail=1
+              echo "::endgroup::"
+              if [ -n "$lint_fail" ]; then
+                  lint_failures="$lint_failures $file";
+              fi
+          done
+
+          if [ -n "$lint_failures" ]; then
+              echo ""
+              echo "dashboard-linter errored for:"
+              for file in $lint_failures
+              do
+                  echo `basename $file`
+              done
+              exit 1
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  render-dashboards:
+  render-lint-dashboards:
     runs-on: ubuntu-22.04
 
     strategy:
@@ -48,23 +48,6 @@ jobs:
           do
               jsonnet -J vendor --tla-code 'datasources=["prometheus-test"]' --output-file rendered-dashboards/`basename $file` $file
           done
-
-      - name: Upload rendered dashboards
-        uses: actions/upload-artifact@v4
-        with:
-          name: rendered-dashboards-${{ github.run_attempt }}
-          path: ./rendered-dashboards
-
-  lint-dashboards:
-    runs-on: ubuntu-22.04
-    needs: [render-dashboards]
-
-    steps:
-      - name: Download rendered dashboards
-        uses: actions/download-artifact@v4
-        with:
-          name: rendered-dashboards-${{ github.run_attempt }}
-          path: ./rendered-dashboards
 
       - name: Install dashboard-linter
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+rendered-dashboards
+
+# ---
+
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
This projects use jsonnet to render grafana dashboard definitions (json). Our pre-commit hooks ensures we have formatted and valid jsonnet files, but until now we haven't done checks on the rendered grafana dashboards.

The only input variable for rendering dashboard definitions is a list of datasource names for the global dashboard. This makes the rendered dashboards very very similar between admins rendering them for their respective deployments, and therefore linting one is to lint them all pretty much.

I've not used grafana/dashboard-linter myself before, and I just searched for a linter as a way to have some kind of test on the validity of the rendered dashboards. I don't know if and what rules make sense etc, but figured this could help us maintain this project.

https://github.com/grafana/dashboard-linter/blob/main/docs/index.md#rules

## Future improvement ideas

- Extract logic so this is easy and quick to run locally also assuming relevant binaries are on PATH