### PR TITLE
pre-commit: add jsonnet-lint hook (with workaround for bug)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,36 @@ repos:
     rev: v0.20.0
     hooks:
       - id: jsonnet-format
-      # jsonnet-lint hook doesn't work
-      # - id: jsonnet-lint
+      # To workaround https://github.com/google/go-jsonnet/issues/591, we run
+      # the jsonnet-lint hook once per .jsonnet / .libsonnet file.
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint cluster.jsonnet
+        args: [-J, vendor, dashboards/cluster.jsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint jupyterhub.jsonnet
+        args: [-J, vendor, dashboards/jupyterhub.jsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint jupyterhub.libsonnet
+        args: [-J, vendor, dashboards/jupyterhub.libsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint support.jsonnet
+        args: [-J, vendor, dashboards/support.jsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint usage-report.jsonnet
+        args: [-J, vendor, dashboards/usage-report.jsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint user.jsonnet
+        args: [-J, vendor, dashboards/user.jsonnet]
+      - id: jsonnet-lint
+        pass_filenames: false
+        name: jsonnet-lint global-usage-stats.jsonnet
+        args: [-J, vendor, global-dashboards/global-usage-stats.jsonnet]
 
   # Autoformat: Python code, syntax patterns are modernized
   - repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
I'll skip attempting to fix these failures in order to avoid merge conflicts. The main branch failures are:

```
dashboards/jupyterhub.jsonnet:6:7-38 Unused variable: singlestat
local singlestat = grafana.singlestat;

dashboards/user.jsonnet:4:7-38 Unused variable: singlestat
local singlestat = grafana.singlestat;

dashboards/user.jsonnet:8:7-38 Unused variable: tablePanel
local tablePanel = grafana.tablePanel;

dashboards/user.jsonnet:9:7-24 Unused variable: row
local row = grafana.row;

dashboards/user.jsonnet:10:7-42 Unused variable: heatmapPanel
local heatmapPanel = grafana.heatmapPanel;
```

The `jsonnet-lint` command (and pre-commit hook) has an issue if being passed multiple files, so we'll simply lint once per file for now. The bug is reported in https://github.com/google/go-jsonnet/issues/591.