### PR TITLE
Fail loudly if `GRAFANA_TOKEN` or `jsonnet` isn't available

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -211,6 +211,13 @@ def main():
             "The environment variable GRAFANA_TOKEN needs to be set in order to deploying dashboards to a Grafana deployment."
         )
 
+    # ensure jsonnet (go-jsonnet)
+    if not shutil.which("jsonnet"):
+        raise ValueError(
+            "No jsonnet binary was found on path! "
+            "Install go-jsonnet via https://github.com/google/go-jsonnet/releases."
+        )
+
     api = partial(
         grafana_request,
         args.grafana_url,

--- a/deploy.py
+++ b/deploy.py
@@ -217,6 +217,12 @@ def main():
             "No jsonnet binary was found on path! "
             "Install go-jsonnet via https://github.com/google/go-jsonnet/releases."
         )
+    jsonnet_version = subprocess.check_output(["jsonnet", "--version"], text=True)
+    if "go" not in jsonnet_version.casefold():
+        print(
+            "WARNING: The jsonnet binary on path doesn't seem to be go-jsonnet from https://github.com/google/go-jsonnet/releases! "
+            "Only that jsonnet implementation is known to work."
+        )
 
     api = partial(
         grafana_request,

--- a/deploy.py
+++ b/deploy.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import ssl
 import subprocess
 from copy import deepcopy
@@ -203,7 +204,12 @@ def main():
 
     args = parser.parse_args()
 
-    grafana_token = os.environ['GRAFANA_TOKEN']
+    # ensure GRAFANA_TOKEN
+    grafana_token = os.environ.get("GRAFANA_TOKEN")
+    if not grafana_token:
+        raise ValueError(
+            "The environment variable GRAFANA_TOKEN needs to be set in order to deploying dashboards to a Grafana deployment."
+        )
 
     api = partial(
         grafana_request,


### PR DESCRIPTION
- Closes https://github.com/jupyterhub/grafana-dashboards/issues/112

The deploy.py script doesn't work if either `GRAFANA_TOKEN` isn't set, or if `jsonnet` isn't available on path. This PR makes the failure verbose instead of showing up as an error harder to read later.

It doesn't fail if go-jsonnet isn't detected, but warns - because maybe it works at some time in the future with the non-golang based version of `jsonnet` for example.

## Related
- #123 