### PR TITLE
add 20th percentile for server startup timing

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -230,6 +230,11 @@ local serverStartTimes =
       'histogram_quantile(0.5, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
     )
     + prometheus.withLegendFormat('50th percentile'),
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      'histogram_quantile(0.2, sum(rate(jupyterhub_server_spawn_duration_seconds_bucket{app="jupyterhub", namespace=~"$hub"}[5m])) by (le))',
+    )
+    + prometheus.withLegendFormat('20th percentile'),
   ]);
 
 local serverSpawnFailures =


### PR DESCRIPTION
we've come to find that adding the 20th percentile to server startup times shows us a more realistic view of a general single user server startup duration.

![image](https://github.com/jupyterhub/grafana-dashboards/assets/1606572/31cfd991-e94f-4ec9-baf7-b9d4d63183dd)

this is highly non-critical, but very useful.  :)