### PR TITLE
Add homedirectory reporting grafana dashboard

### DIFF
--- a/dashboards/homedirs.jsonnet
+++ b/dashboards/homedirs.jsonnet
@@ -8,26 +8,35 @@ local common = import './common.libsonnet';
 
 local homedirUsage =
   table.new('Home directory usage')
+  + table.panelOptions.withDescription(
+    |||
+      Home directory usage by various users on the hub.
+
+      Requires an installation of https://github.com/yuvipanda/prometheus-dirsize-exporter to work.
+      If this table is empty, your infrastructure administrator needs to deploy that exporter correctly.
+    |||
+  )
   + table.queryOptions.withTargets([
+    // Last Modified
     prometheus.new(
       '$PROMETHEUS_DS',
       |||
         min(dirsize_latest_mtime{namespace=~"$hub"}) by (directory) * 1000
       |||
     )
-    + prometheus.withLegendFormat('Last Modified')
-    + prometheus.withInstant(true)
+    + prometheus.withInstant(true)  // Only fetch latest value
     + prometheus.withFormat('table')
     ,
+    // Total Size
     prometheus.new(
       '$PROMETHEUS_DS',
       |||
         max(dirsize_total_size_bytes{namespace=~"$hub"}) by (directory)
       |||
     )
-    + prometheus.withLegendFormat('Total Size')
     + prometheus.withInstant(true)
     + prometheus.withFormat('table'),
+    // % of total usage
     prometheus.new(
       '$PROMETHEUS_DS',
       |||
@@ -36,19 +45,19 @@ local homedirUsage =
         ignoring (directory) group_left sum(dirsize_total_size_bytes{namespace=~"$hub"})
       |||
     )
-    + prometheus.withLegendFormat('% of total space used')
     + prometheus.withInstant(true)
     + prometheus.withFormat('table'),
+    // Total number of files
     prometheus.new(
       '$PROMETHEUS_DS',
       |||
         max(dirsize_entries_count{namespace=~"$hub"}) by (directory)
       |||
     )
-    + prometheus.withLegendFormat('Number of entries')
     + prometheus.withInstant(true)
     + prometheus.withFormat('table'),
   ])
+  // Transform table from multiple series with same key to one unified table with shared key 'directory'
   + table.queryOptions.withTransformations([
     table.queryOptions.transformation.withId('joinByField')
     + table.queryOptions.transformation.withOptions({
@@ -60,14 +69,17 @@ local homedirUsage =
     + table.queryOptions.transformation.withOptions({
       // Grafana adds an individual 'Time #N' column for each timeseries we get.
       // They all display the same time. We don't care about time *at all*, since
-      // all these are instant data query targets. So we hide all the time values.
+      // all these are instant data query targets that only display latest
+      // values. So we hide all the time values.
       excludeByName: {
         'Time 1': true,
         'Time 2': true,
         'Time 3': true,
         'Time 4': true,
       },
-      // Explicitly rename the column headers, so they do not display 'Value #N'
+      // Tables do not use the legend keys, and show Value #N for each Time #N. We
+      // explicitly rename these here. This depends on the ordering of these series
+      // above, so if the ordering changes, so must this.
       renameByName: {
         'Value #A': 'Last Modified',
         'Value #B': 'Size',
@@ -78,10 +90,12 @@ local homedirUsage =
   ])
   + {
     fieldConfig: {
+      // Set units for all the columns. These can not be set elsewhere for tables
       overrides: [
         {
           matcher: {
             id: 'byName',
+            // This is name provided by the `renameByName` transform
             options: 'Size',
           },
           properties: [
@@ -94,6 +108,7 @@ local homedirUsage =
         {
           matcher: {
             id: 'byName',
+            // This is name provided by the `renameByName` transform
             options: 'Last Modified',
           },
           properties: [
@@ -106,6 +121,7 @@ local homedirUsage =
         {
           matcher: {
             id: 'byName',
+            // This is name provided by the `renameByName` transform
             options: 'Number of Entries',
           },
           properties: [
@@ -118,6 +134,7 @@ local homedirUsage =
         {
           matcher: {
             id: 'byName',
+            // This is name provided by the `renameByName` transform
             options: '% of total space usage',
           },
           properties: [

--- a/dashboards/homedirs.jsonnet
+++ b/dashboards/homedirs.jsonnet
@@ -139,5 +139,7 @@ dashboard.new('Home Directory Usage Dashboard')
   common.variables.hub,
 ])
 + dashboard.withPanels(
-  homedirUsage
+  grafonnet.util.grid.makeGrid([
+    homedirUsage,
+  ], panelWidth=24, panelHeight=24)
 )

--- a/dashboards/homedirs.jsonnet
+++ b/dashboards/homedirs.jsonnet
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S jsonnet -J ../vendor
+local grafonnet = import 'grafonnet/main.libsonnet';
+local dashboard = grafonnet.dashboard;
+local prometheus = grafonnet.query.prometheus;
+local table = grafonnet.panel.table;
+
+local common = import './common.libsonnet';
+
+local homedirUsage =
+  table.new('Home directory usage')
+  + table.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        min(dirsize_latest_mtime{namespace=~"$hub"}) by (directory) * 1000
+      |||
+    )
+    + prometheus.withLegendFormat('Last Modified')
+    + prometheus.withInstant(true)
+    + prometheus.withFormat('table')
+    ,
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        max(dirsize_total_size_bytes{namespace=~"$hub"}) by (directory)
+      |||
+    )
+    + prometheus.withLegendFormat('Total Size')
+    + prometheus.withInstant(true)
+    + prometheus.withFormat('table'),
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        max(dirsize_total_size_bytes{namespace=~"$hub"}) by (directory)
+        /
+        ignoring (directory) group_left sum(dirsize_total_size_bytes{namespace=~"$hub"})
+      |||
+    )
+    + prometheus.withLegendFormat('% of total space used')
+    + prometheus.withInstant(true)
+    + prometheus.withFormat('table'),
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        max(dirsize_entries_count{namespace=~"$hub"}) by (directory)
+      |||
+    )
+    + prometheus.withLegendFormat('Number of entries')
+    + prometheus.withInstant(true)
+    + prometheus.withFormat('table'),
+  ])
+  + table.queryOptions.withTransformations([
+    table.queryOptions.transformation.withId('joinByField')
+    + table.queryOptions.transformation.withOptions({
+      byField: 'directory',
+      mode: 'outer',
+    }),
+
+    table.queryOptions.transformation.withId('organize')
+    + table.queryOptions.transformation.withOptions({
+      // Grafana adds an individual 'Time #N' column for each timeseries we get.
+      // They all display the same time. We don't care about time *at all*, since
+      // all these are instant data query targets. So we hide all the time values.
+      excludeByName: {
+        'Time 1': true,
+        'Time 2': true,
+        'Time 3': true,
+        'Time 4': true,
+      },
+      // Explicitly rename the column headers, so they do not display 'Value #N'
+      renameByName: {
+        'Value #A': 'Last Modified',
+        'Value #B': 'Size',
+        'Value #C': '% of total space usage',
+        'Value #D': 'Number of Entries',
+      },
+    }),
+  ])
+  + {
+    fieldConfig: {
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Size',
+          },
+          properties: [
+            {
+              id: 'unit',
+              value: 'bytes',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Last Modified',
+          },
+          properties: [
+            {
+              id: 'unit',
+              value: 'dateTimeFromNow',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Number of Entries',
+          },
+          properties: [
+            {
+              id: 'unit',
+              value: 'short',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: '% of total space usage',
+          },
+          properties: [
+            {
+              id: 'unit',
+              value: 'percentunit',
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+dashboard.new('Home Directory Usage Dashboard')
++ dashboard.withTags(['jupyterhub'])
++ dashboard.withEditable(true)
++ dashboard.withVariables([
+  common.variables.prometheus,
+  common.variables.hub,
+])
++ dashboard.withPanels(
+  homedirUsage
+)

--- a/docs/tutorials/deploy.md
+++ b/docs/tutorials/deploy.md
@@ -221,6 +221,8 @@ spec:
 
 You will likely only need to adjust the `claimName` above to use this example.
 
+This is required for the "Home directory usage" dashboard.
+
 ## Deploy the dashbaords
 
 There's a helper `deploy.py` script that can deploy the dashboards to any grafana installation.


### PR DESCRIPTION
Adds a sortable home directory table that makes it much much easier to see who is using what. This is an addition to the same information shown as a timeseries in the user diagnostics dashboard.

<img width="1607" alt="Screenshot 2024-07-19 at 9 59 54 AM" src="https://github.com/user-attachments/assets/92e60621-3ce0-44c4-9d85-f819c9518857">

(I've blanked out the usernames for privacy)

This has been used in production for a while, and is very helpful in finding users who inadvertently use terabytes of storage.