### PR TITLE
Remove warning about only supporting go-jsonnet

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -130,17 +130,11 @@ def main():
             "The environment variable GRAFANA_TOKEN needs to be set in order to deploying dashboards to a Grafana deployment."
         )
 
-    # ensure jsonnet (go-jsonnet)
+    # ensure jsonnet
     if not shutil.which("jsonnet"):
         raise ValueError(
             "No jsonnet binary was found on path! "
             "Install go-jsonnet via https://github.com/google/go-jsonnet/releases."
-        )
-    jsonnet_version = subprocess.check_output(["jsonnet", "--version"], text=True)
-    if "go" not in jsonnet_version.casefold():
-        print(
-            "WARNING: The jsonnet binary on path doesn't seem to be go-jsonnet from https://github.com/google/go-jsonnet/releases! "
-            "Only that jsonnet implementation is known to work."
         )
 
     api = partial(


### PR DESCRIPTION
I've always used the regular jsonnet implementation without trouble, and continue to do so.

It's technically slower, but at these scales it does not matter. It's also the default you get if you do `brew install jsonnet` or `apt install jsonnet`.