### PR TITLE
Update grafonnet import paths to absolute import paths

### DIFF
--- a/dashboards/activity.jsonnet
+++ b/dashboards/activity.jsonnet
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local ts = grafonnet.panel.timeSeries;
 local prometheus = grafonnet.query.prometheus;

--- a/dashboards/cluster.jsonnet
+++ b/dashboards/cluster.jsonnet
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
 // Deploys a dashboard showing cluster-wide information
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local ts = grafonnet.panel.timeSeries;
 local barChart = grafonnet.panel.barChart;

--- a/dashboards/common.libsonnet
+++ b/dashboards/common.libsonnet
@@ -1,4 +1,4 @@
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local ts = grafonnet.panel.timeSeries;
 local barChart = grafonnet.panel.barChart;
 local barGauge = grafonnet.panel.barGauge;

--- a/dashboards/homedirs.jsonnet
+++ b/dashboards/homedirs.jsonnet
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local prometheus = grafonnet.query.prometheus;
 local table = grafonnet.panel.table;

--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
 // Deploys one dashboard - "JupyterHub dashboard",
 // with useful stats about usage & diagnostics.
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local ts = grafonnet.panel.timeSeries;
 local prometheus = grafonnet.query.prometheus;

--- a/dashboards/jupyterhub.libsonnet
+++ b/dashboards/jupyterhub.libsonnet
@@ -1,4 +1,4 @@
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local ts = grafonnet.panel.timeSeries;
 local prometheus = grafonnet.query.prometheus;
 

--- a/dashboards/support.jsonnet
+++ b/dashboards/support.jsonnet
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
 // Deploys a dashboard showing information about support resources
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local ts = grafonnet.panel.timeSeries;
 local prometheus = grafonnet.query.prometheus;

--- a/dashboards/usage-report.jsonnet
+++ b/dashboards/usage-report.jsonnet
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local barGauge = grafonnet.panel.barGauge;
 local prometheus = grafonnet.query.prometheus;

--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S jsonnet -J ../vendor
-local grafonnet = import 'grafonnet/main.libsonnet';
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet';
 local dashboard = grafonnet.dashboard;
 local ts = grafonnet.panel.timeSeries;
 local prometheus = grafonnet.query.prometheus;


### PR DESCRIPTION
# Context
Users integrating the dashboards into mixins might use colliding relative import paths.

This might be for example the case for:
https://github.com/grafana/grafonnet
https://github.com/grafana/grafonnet-lib (subdir grafonnet)

Using absolute import paths instead of relative import paths should resolve this collision for dependencies in distinct repositories.

# Description

This PR updates the relative import paths `grafonnet/main.libsonnet` to absolute import paths `github.com/grafana/grafonnet/gen/grafonnet-v10.4.0/main.libsonnet` to avoid jsonnet import path collisions.