### PR TITLE
Update link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ via code. This can then be deployed on any Grafana instance!
 
 ## Deployment
 
-Deployment instructions are available in [the documentation site](https://jupyterhub-grafana.readthedocs.io/en/latest/howto/deploy.html).
+Deployment instructions are available in [the documentation site](https://jupyterhub-grafana.readthedocs.io/en/latest/tutorials/deploy.html).


### PR DESCRIPTION
The old link (https://jupyterhub-grafana.readthedocs.io/en/latest/howto/deploy.html) currently leads to 404 in Portuguese. New link: https://jupyterhub-grafana.readthedocs.io/en/latest/tutorials/deploy.html