### PR TITLE
Separate pod and user diagnostics

### DIFF
--- a/dashboards/common.libsonnet
+++ b/dashboards/common.libsonnet
@@ -70,6 +70,13 @@ local var = grafonnet.dashboard.variable;
       + var.query.selectionOptions.withIncludeAll(value=true, customAllValue='.*')
       + var.query.queryTypes.withLabelValues('pod', 'kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub"}')
     ,
+    user_name:
+      var.query.new('user_name')
+      + var.query.withDatasourceFromVariable(self.prometheus)
+      + var.query.selectionOptions.withMulti()
+      + var.query.selectionOptions.withIncludeAll(value=true, customAllValue='.*')
+      + var.query.queryTypes.withLabelValues('label_hub_jupyter_org_username', 'kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub"}')
+    ,    
     // Queries should use the 'instance' label when querying metrics that
     // come from collectors present on each node - such as node_exporter or
     // container_ metrics, and use the 'node' label when querying metrics

--- a/dashboards/pod.jsonnet
+++ b/dashboards/pod.jsonnet
@@ -1,0 +1,161 @@
+#!/usr/bin/env -S jsonnet -J ../vendor
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-v11.1.0/main.libsonnet';
+local dashboard = grafonnet.dashboard;
+local ts = grafonnet.panel.timeSeries;
+local prometheus = grafonnet.query.prometheus;
+
+local common = import './common.libsonnet';
+
+local memoryUsage =
+  common.tsOptions
+  + ts.new('Memory Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per-user per-server memory usage
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          # exclude name="" because the same container can be reported
+          # with both no name and `name=k8s_...`,
+          # in which case sum() by (pod) reports double the actual metric
+          container_memory_working_set_bytes{name!="", instance=~"$instance"}
+          * on (namespace, pod) group_left(container)
+          group(
+              kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}
+          ) by (pod, namespace)
+        ) by (pod, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ pod }} - ({{ namespace }})'),
+  ]);
+
+
+local cpuUsage =
+  common.tsOptions
+  + ts.new('CPU Usage')
+  + ts.panelOptions.withDescription(
+    |||
+      Per-user per-server CPU usage
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          # exclude name="" because the same container can be reported
+          # with both no name and `name=k8s_...`,
+          # in which case sum() by (pod) reports double the actual metric
+          irate(container_cpu_usage_seconds_total{name!="", instance=~"$instance"}[5m])
+          * on (namespace, pod) group_left(container)
+          group(
+              kube_pod_labels{label_app="jupyterhub", label_component="singleuser-server", namespace=~"$hub", pod=~"$user_pod"}
+          ) by (pod, namespace)
+        ) by (pod, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ pod }} - ({{ namespace }})'),
+  ]);
+
+local homedirSharedUsage =
+  common.tsOptions
+  + ts.new('Home Directory Usage (on shared home directories)')
+  + ts.panelOptions.withDescription(
+    |||
+      Per user home directory size, when using a shared home directory.
+
+      Requires https://github.com/yuvipanda/prometheus-dirsize-exporter to
+      be set up.
+
+      Similar to server pod names, user names will be *encoded* here
+      using the escapism python library (https://github.com/minrk/escapism).
+      You can unencode them with the following python snippet:
+
+      from escapism import unescape
+      unescape('<escaped-username>', '-')
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        max(
+          dirsize_total_size_bytes{namespace="$hub"}
+        ) by (directory, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ directory }} - ({{ namespace }})'),
+  ]);
+
+local memoryRequests =
+  common.tsOptions
+  + ts.new('Memory Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per-user per-server memory Requests
+    |||
+  )
+  + ts.standardOptions.withUnit('bytes')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="memory", namespace=~"$hub", node=~"$instance"}
+        ) by (pod, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ pod }} - ({{ namespace }})'),
+  ]);
+
+local cpuRequests =
+  common.tsOptions
+  + ts.new('CPU Requests')
+  + ts.panelOptions.withDescription(
+    |||
+      Per-user per-server CPU Requests
+    |||
+  )
+  + ts.standardOptions.withUnit('percentunit')
+  + ts.queryOptions.withTargets([
+    prometheus.new(
+      '$PROMETHEUS_DS',
+      |||
+        sum(
+          kube_pod_container_resource_requests{resource="cpu", namespace=~"$hub", node=~"$instance"}
+        ) by (pod, namespace)
+      |||
+    )
+    + prometheus.withLegendFormat('{{ pod }} - ({{ namespace }})'),
+  ]);
+
+dashboard.new('Pod Diagnostics Dashboard')
++ dashboard.withTags(['jupyterhub'])
++ dashboard.withUid('user-pod-diagnostics-dashboard')
++ dashboard.withEditable(true)
++ dashboard.withVariables([
+  common.variables.prometheus,
+  common.variables.hub,
+  common.variables.user_pod,
+  common.variables.instance,
+])
++ dashboard.withPanels(
+  grafonnet.util.grid.makeGrid(
+    [
+      memoryUsage,
+      cpuUsage,
+      homedirSharedUsage,
+      memoryRequests,
+      cpuRequests,
+    ],
+    panelWidth=24,
+    panelHeight=12,
+  )
+)

--- a/docs/howto/user-diagnostics.md
+++ b/docs/howto/user-diagnostics.md
@@ -1,9 +1,13 @@
 # Look at individual user metrics
 
 A common support request for JupyterHub admins pertains to specific issues
-faced by a particular user. The "User Diagnostics" dashboard helps with this.
-It also helps look for *outliers* in a hub - people using too much of a particular
-resource, or not enough of a particular resource.
+faced by a particular user. The "User Diagnostics" dashboard helps displaying
+metrics on a per-user level. It also helps look for *outliers* in a hub –
+people using too much of a particular resource, or not enough of a particular
+resource.
+
+The "Pod Diagnostics" dashboard displays metrics on a per-user per-server level.
+For example, a JupyterHub can be configured to [allow multiple named servers per user](https://jupyterhub.readthedocs.io/en/stable/howto/configuration/config-user-env.html#named-servers) running at the same time.
 
 ## Home directory size (with shared volumes)
 


### PR DESCRIPTION
### Context

The current "User Diagnostics" dashboard is technically a "Pod Diagnostics" dashboard.

In JupyterHubs where [named servers](https://jupyterhub.readthedocs.io/en/stable/howto/configuration/config-user-env.html#named-servers) are enabled, we can have multiple singleuser servers associated with one user.

This PR separates the two use cases into

- Pod Diagnostics: per-user per-server
- User Diagnostics: per-user

by updating PromQL to make use of the `label_hub_jupyter_org_username` selector of the `kube_pod_labels` metric picked up from the [_build_common_labels](https://github.com/jupyterhub/kubespawner/blob/9e994a7ce7507196ec2258460836eef40c98d0e1/kubespawner/spawner.py#L2146) method of Kubespawner.