### PR TITLE
Regex match namespace in homedir user query

### DIFF
--- a/dashboards/user.jsonnet
+++ b/dashboards/user.jsonnet
@@ -87,7 +87,7 @@ local homedirSharedUsage =
       '$PROMETHEUS_DS',
       |||
         max(
-          dirsize_total_size_bytes{namespace="$hub"}
+          dirsize_total_size_bytes{namespace=~"$hub"}
         ) by (directory, namespace)
       |||
     )


### PR DESCRIPTION
Existing exact match causes a dashboard with no data when using a regex such as `namespace=".*"`.

Before:
![image](https://github.com/user-attachments/assets/849a8879-0ffa-47f4-889b-6224c870ee0c)

After:
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/9056dffb-25bc-4351-83e2-5655be6f806d" />


Addresses #110