### PR TITLE
count response codes only once

### DIFF
--- a/dashboards/jupyterhub.jsonnet
+++ b/dashboards/jupyterhub.jsonnet
@@ -163,7 +163,7 @@ local hubResponseCodes =
       |||
         sum(
           increase(
-            jupyterhub_request_duration_seconds_bucket{
+            jupyterhub_request_duration_seconds_count{
               app="jupyterhub",
               namespace=~"$hub",
             }[2m]


### PR DESCRIPTION
In general, when dealing with `buckets`, counts must be split over `le`. But one metric, `hubResponseCodes`, sums over `code` only, which ends up counting each request once _per bucket_ they match, since buckets are "less than or equal" and not mutually exclusive, resulting in over-counting requests by ~15x (the number of buckets). I became suspicious when my deployment had ~3k steady 200 responses every 2 minutes with ~20 active users. The real number was ~180.

sum of buckets over code (before this PR):

![Screenshot 2025-06-19 at 14 57 50](https://github.com/user-attachments/assets/0f2a2604-0fcf-4e6f-99f5-670c067fc125)

Sum of buckets over code, le, showing double count:

![Screenshot 2025-06-19 at 14 57 35](https://github.com/user-attachments/assets/eb1f38bb-0d9b-4847-9db3-c48c51e3f4f2)


Sum of count over code (this PR), matches the `le=+inf` value above:

![Screenshot 2025-06-19 at 15 00 37](https://github.com/user-attachments/assets/a3c3c713-8438-417d-bdf4-df21b03b2afa)
